### PR TITLE
feat: add hero search bar on landing page with marketplace text search

### DIFF
--- a/src/components/LandingPage/LandingPage.css
+++ b/src/components/LandingPage/LandingPage.css
@@ -1600,6 +1600,97 @@
     height: 45px;
   }
 }
+/* ── Hero Search Bar ── */
+.hero-search {
+  margin-bottom: 1.75rem;
+  max-width: 520px;
+}
+
+.hero-search-inner {
+  display: flex;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 12px;
+  backdrop-filter: blur(12px);
+  overflow: hidden;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.hero-search-inner:focus-within {
+  border-color: rgba(71, 239, 172, 0.55);
+  box-shadow: 0 0 0 3px rgba(71, 239, 172, 0.12);
+}
+
+.hero-search-icon {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  color: rgba(255, 255, 255, 0.45);
+  margin-left: 1rem;
+}
+
+.hero-search-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  padding: 0.85rem 0.75rem;
+  font-size: 0.9rem;
+  font-family: 'Inter', sans-serif;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.hero-search-input::placeholder {
+  color: rgba(255, 255, 255, 0.38);
+}
+
+.hero-search-btn {
+  flex-shrink: 0;
+  background: #47EFAC;
+  color: #072973;
+  border: none;
+  padding: 0.85rem 1.4rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  font-family: 'Inter', sans-serif;
+  cursor: pointer;
+  letter-spacing: 0.3px;
+  transition: background 0.2s ease;
+}
+
+.hero-search-btn:hover {
+  background: #5ff7b9;
+}
+
+@media (max-width: 768px) {
+  .hero-search {
+    max-width: 100%;
+  }
+
+  .hero-search-input {
+    font-size: 0.85rem;
+    padding: 0.75rem 0.6rem;
+  }
+
+  .hero-search-btn {
+    padding: 0.75rem 1.1rem;
+    font-size: 0.8rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-search-input {
+    font-size: 0.8rem;
+    padding: 0.7rem 0.5rem;
+  }
+
+  .hero-search-btn {
+    padding: 0.7rem 0.9rem;
+    font-size: 0.75rem;
+  }
+}
+
 /* ── Phone loader (shown by Suspense while 3D assets fetch) ── */
 .phone-loader {
   width: 100%;

--- a/src/components/LandingPage/LandingPage.jsx
+++ b/src/components/LandingPage/LandingPage.jsx
@@ -2,6 +2,7 @@ import { motion } from "framer-motion";
 import { Helmet } from "react-helmet-async";
 import "./LandingPage.css";
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { API_URL } from "../../API_URL";
 import GooglePlay from '../../assets/headers/GooglePlay.png';
 import Apple from '../../assets/headers/Apple.png';
@@ -9,6 +10,8 @@ import IphoneModel from './IphoneModel';
 import HowItWorks from './HowItWorks';
 
 const LandingPage = () => {
+  const navigate = useNavigate();
+  const [searchQuery, setSearchQuery] = useState("");
   const [signUpLink, setSignUpLink] = useState("/signup");
   const [kickStarterlink, setKickStarterLink] = useState(
     "https://www.kickstarter.com/projects/132225890/immpression-presents-the-digital-gallery-movement?ref=discovery&term=immpression&total_hits=247&category_id=332"
@@ -100,6 +103,12 @@ const LandingPage = () => {
    * `animate` is keyed to fontsReady — nothing moves until fonts are loaded,
    * so the first frame the user ever sees has the correct typeface already in place.
    */
+  const handleSearch = (e) => {
+    e.preventDefault();
+    const q = searchQuery.trim();
+    navigate(q ? `/marketplace?q=${encodeURIComponent(q)}` : "/marketplace");
+  };
+
   const fade = (delay) => ({
     initial: { opacity: 0 },
     animate: { opacity: fontsReady ? 1 : 0 },
@@ -139,6 +148,22 @@ const LandingPage = () => {
               Search thousands of artworks, discover emerging artists, and buy
               original pieces directly from creators — all in one place.
             </motion.p>
+
+            <motion.form className="hero-search" onSubmit={handleSearch} {...fade(0.36)}>
+              <div className="hero-search-inner">
+                <svg className="hero-search-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" />
+                </svg>
+                <input
+                  type="text"
+                  className="hero-search-input"
+                  placeholder="Search by artist, style, keyword, or anything..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                />
+                <button type="submit" className="hero-search-btn">Search</button>
+              </div>
+            </motion.form>
 
             <motion.div className="hero-pills" {...fade(0.4)}>
               <span className="hero-pill">✦ Search Thousands of Artworks</span>

--- a/src/components/Marketplace/Marketplace.jsx
+++ b/src/components/Marketplace/Marketplace.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { motion } from "framer-motion";
 import { Helmet } from "react-helmet-async";
+import { useSearchParams } from "react-router-dom";
 import ArtCard from "./ArtCard.jsx";
 import "./Marketplace.css";
 import { API_URL } from "../../API_URL";
@@ -25,12 +26,14 @@ const SORT_OPTIONS = [
 ];
 
 const Marketplace = () => {
+  const [searchParams] = useSearchParams();
   const [artworks, setArtworks] = useState([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState("");
   const [category, setCategory] = useState("All");
   const [sort, setSort] = useState("newest");
+  const [search, setSearch] = useState(() => searchParams.get("q") || "");
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [totalImages, setTotalImages] = useState(0);
@@ -50,6 +53,7 @@ const Marketplace = () => {
         sort,
       });
       if (category !== "All") params.append("category", category);
+      if (search.trim()) params.append("q", search.trim());
 
       const res = await fetch(`${API_URL}/marketplace?${params}`);
       const data = await res.json();
@@ -69,7 +73,12 @@ const Marketplace = () => {
       setLoading(false);
       setLoadingMore(false);
     }
-  }, [category, sort]);
+  }, [category, sort, search]);
+
+  useEffect(() => {
+    const q = searchParams.get("q") || "";
+    setSearch(q);
+  }, [searchParams]);
 
   useEffect(() => {
     fetchArtworks(1, true);


### PR DESCRIPTION
- Landing page: search bar under hero subtitle (icon + input + Search button) navigates to /marketplace?q=<query>
- Marketplace: reads ?q URL param and passes to backend on fetch
- Backend: /marketplace route supports q param for text search across name, artistName, description, category


Claude-Session: https://claude.ai/code/session_01QK3pHMoW7QKDnr4DGNXcDe