### PR TITLE
feat: mobile landing page redesign and HowItWorks mobile responsiveness

### DIFF
--- a/src/components/LandingPage/HowItWorks.css
+++ b/src/components/LandingPage/HowItWorks.css
@@ -252,39 +252,148 @@
 }
 
 /* ─────────────────────────────────────────
+   Static phone mockup — mobile only
+───────────────────────────────────────── */
+.hiw-phone-static-wrap {
+  display: none; /* hidden on desktop — 3D model shows instead */
+}
+
+.hiw-phone-shell {
+  position: relative;
+  width: 210px;
+  margin: 0 auto;
+  background: #0f0f0f;
+  border-radius: 42px;
+  padding: 13px;
+  box-shadow:
+    0 0 0 1.5px rgba(255,255,255,0.13),
+    0 28px 72px rgba(0,0,0,0.7),
+    inset 0 0 0 1px rgba(255,255,255,0.05);
+}
+
+/* Power button */
+.hiw-phone-shell::before {
+  content: '';
+  position: absolute;
+  right: -3px;
+  top: 90px;
+  width: 3px;
+  height: 52px;
+  background: #222;
+  border-radius: 0 2px 2px 0;
+}
+
+/* Volume buttons */
+.hiw-phone-shell::after {
+  content: '';
+  position: absolute;
+  left: -3px;
+  top: 68px;
+  width: 3px;
+  height: 30px;
+  background: #222;
+  border-radius: 2px 0 0 2px;
+  box-shadow: 0 46px 0 #222;
+}
+
+/* Dynamic Island */
+.hiw-phone-island {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 76px;
+  height: 22px;
+  background: #000;
+  border-radius: 999px;
+  z-index: 2;
+}
+
+.hiw-phone-screen {
+  border-radius: 30px;
+  overflow: hidden;
+  aspect-ratio: 9 / 19.5;
+  background: #000;
+}
+
+.hiw-phone-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: top center;
+  display: block;
+}
+
+/* Home indicator */
+.hiw-phone-bar {
+  width: 76px;
+  height: 4px;
+  background: rgba(255,255,255,0.22);
+  border-radius: 999px;
+  margin: 10px auto 0;
+}
+
+/* ─────────────────────────────────────────
    Responsive
 ───────────────────────────────────────── */
 @media (max-width: 960px) {
+  .hiw-section { padding: 4rem 1.5rem; }
+
   .hiw-container {
     grid-template-columns: 1fr;
-    gap: 2.5rem;
+    gap: 2rem;
+  }
+
+  /* Reset all explicit column placements so items stack naturally */
+  .hiw-col-text,
+  .hiw-col-phone,
+  .hiw-col-steps {
+    grid-column: auto;
   }
 
   .hiw-col-phone { display: none; }
 
+  .hiw-phone-static-wrap {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
   .hiw-col-text {
+    margin-left: 0;
+    padding-right: 0;
     align-items: center;
     text-align: center;
+    width: 100%;
+    align-self: auto;
   }
+
+  .hiw-section-label { margin-bottom: 1.75rem; }
+
+  .hiw-title-line { font-size: 2.4rem; }
+
   .hiw-subtitle { margin: 0 auto 1.5rem; }
+
   .hiw-paint-stroke { margin-left: auto; margin-right: auto; }
+
   .hiw-spray { display: none; }
 
   .hiw-col-steps {
-    max-width: 500px;
+    max-width: 480px;
     margin: 0 auto;
     width: 100%;
     padding-left: 0;
   }
 
   .hiw-step-desc { max-width: 100%; }
-
-  .hiw-title-line { font-size: 2.4rem; }
 }
 
 @media (max-width: 600px) {
-  .hiw-section { padding: 4rem 1.25rem; }
+  .hiw-section { padding: 3.5rem 1.25rem; }
+  .hiw-section-label { font-size: 1.6rem; margin-bottom: 1.5rem; }
   .hiw-title-line { font-size: 2rem; }
   .hiw-step { padding: 1.25rem 0; }
   .hiw-ghost-num { font-size: 4rem; }
+  .hiw-step-title { font-size: 1rem; letter-spacing: 2px; }
+  .hiw-step-desc { font-size: 0.82rem; }
 }

--- a/src/components/LandingPage/HowItWorks.jsx
+++ b/src/components/LandingPage/HowItWorks.jsx
@@ -1,6 +1,7 @@
 import { motion } from "framer-motion";
 import { Suspense } from "react";
 import IphoneModel from "./IphoneModel";
+import ImmpressionHome from "../../assets/backgrounds/ImmpressionHome.png";
 import "./HowItWorks.css";
 
 const steps = [
@@ -124,11 +125,26 @@ const HowItWorks = () => {
           <SprayCluster />
         </motion.div>
 
-        {/* ── Col 2: phone ── */}
+        {/* ── Col 2: 3D phone (desktop only) ── */}
         <div className="hiw-col hiw-col-phone">
           <Suspense fallback={null}>
             <IphoneModel />
           </Suspense>
+        </div>
+
+        {/* ── Static phone mockup (mobile only) ── */}
+        <div className="hiw-phone-static-wrap">
+          <div className="hiw-phone-shell">
+            <div className="hiw-phone-island" aria-hidden="true" />
+            <div className="hiw-phone-screen">
+              <img
+                src={ImmpressionHome}
+                alt="Immpression app screenshot"
+                className="hiw-phone-img"
+              />
+            </div>
+            <div className="hiw-phone-bar" aria-hidden="true" />
+          </div>
         </div>
 
         {/* ── Col 3: steps ── */}

--- a/src/components/LandingPage/LandingPage.css
+++ b/src/components/LandingPage/LandingPage.css
@@ -1136,6 +1136,11 @@
 }
 
 @media (max-width: 768px) {
+  /* MobileLanding replaces the entire hero section on mobile */
+  .hero-section {
+    display: none;
+  }
+
   .hero-mosaic-panel {
     display: none;
   }

--- a/src/components/LandingPage/LandingPage.jsx
+++ b/src/components/LandingPage/LandingPage.jsx
@@ -10,6 +10,7 @@ import Apple from '../../assets/headers/Apple.png';
 import ArtMosaic from './ArtMosaic';
 import HowItWorks from './HowItWorks';
 import FeaturedArticles from './FeaturedArticles';
+import MobileLanding from './MobileLanding';
 
 const LandingPage = () => {
   const navigate = useNavigate();
@@ -218,6 +219,7 @@ const LandingPage = () => {
                 <img src={Apple} alt="Download on the App Store" className="google-play-img" />
               </a>
             </motion.div>
+
           </div>
 
           {/* empty spacer keeps the 2-column grid intact */}
@@ -256,6 +258,12 @@ const LandingPage = () => {
           </div>
         </div>
       </section>
+
+      <MobileLanding
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+        onSearch={handleSearch}
+      />
 
       <FeaturedArticles />
       <HowItWorks />

--- a/src/components/LandingPage/MobileLanding.css
+++ b/src/components/LandingPage/MobileLanding.css
@@ -1,0 +1,495 @@
+@import url('https://fonts.googleapis.com/css2?family=Permanent+Marker&family=Inter:wght@400;500;600;700&display=swap');
+
+/* ─────────────────────────────────────────
+   Mobile Landing Page (mlp-*)
+   Hidden on desktop — shown only ≤768px.
+   Background is inherited from .landing-wrapper.
+───────────────────────────────────────── */
+
+.mlp {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .mlp {
+    display: block;
+  }
+}
+
+/* ── Hero ─────────────────────────────── */
+.mlp-hero {
+  position: relative;
+  overflow: hidden;
+  padding: 5.5rem 1.5rem 2.25rem;
+}
+
+/* Corner paint splashes */
+.mlp-splash {
+  position: absolute;
+  pointer-events: none;
+  z-index: 0;
+}
+.mlp-splash-tl {
+  top: -16px;
+  left: -16px;
+  width: 240px;
+  height: 260px;
+}
+.mlp-splash-tr {
+  top: -8px;
+  right: -16px;
+  width: 200px;
+  height: 200px;
+}
+
+/* Eyebrow */
+.mlp-eyebrow {
+  position: relative;
+  z-index: 1;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.67rem;
+  font-weight: 700;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: #47EFAC;
+  margin: 0 0 1.2rem;
+}
+
+/* H1 */
+.mlp-title {
+  position: relative;
+  z-index: 1;
+  font-family: 'Permanent Marker', cursive;
+  font-size: 3.2rem;
+  font-weight: 400;
+  color: #ffffff;
+  line-height: 1.1;
+  margin: 0 0 1.1rem;
+  letter-spacing: 0.01em;
+}
+
+.mlp-accent {
+  background: linear-gradient(135deg, #47EFAC 0%, #7eb8ff 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* Subtitle */
+.mlp-subtitle {
+  position: relative;
+  z-index: 1;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.65);
+  line-height: 1.65;
+  margin: 0 0 1.75rem;
+  max-width: 340px;
+}
+
+/* ── Search bar ─────────────────────────── */
+.mlp-search {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  background: #ffffff;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow:
+    0 16px 48px rgba(0, 0, 0, 0.5),
+    0 4px 14px rgba(0, 0, 0, 0.3);
+  margin-bottom: 1rem;
+}
+
+.mlp-search-icon {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  color: #aaaaaa;
+  margin-left: 1rem;
+}
+
+.mlp-search-input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  padding: 1rem 0.75rem;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.9rem;
+  color: #111111;
+}
+
+.mlp-search-input::placeholder {
+  color: #bbbbbb;
+}
+
+.mlp-search-btn {
+  flex-shrink: 0;
+  background: #072973;
+  color: #ffffff;
+  border: none;
+  padding: 1rem 1.35rem;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.875rem;
+  font-weight: 700;
+  cursor: pointer;
+  letter-spacing: 0.3px;
+  transition: background 0.2s;
+  white-space: nowrap;
+}
+
+.mlp-search-btn:active {
+  background: #0a3a9e;
+}
+
+/* ── Trending chips ─────────────────────── */
+.mlp-trending {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 1.75rem;
+}
+
+.mlp-trending-label {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.67rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.mlp-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.mlp-chip {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: rgba(255, 255, 255, 0.82);
+  font-family: 'Inter', sans-serif;
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.33rem 0.88rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.18s, border-color 0.18s, color 0.18s;
+  backdrop-filter: blur(6px);
+}
+
+.mlp-chip:active {
+  background: rgba(71, 239, 172, 0.18);
+  border-color: rgba(71, 239, 172, 0.45);
+  color: #47EFAC;
+}
+
+/* ── App store buttons ──────────────────── */
+.mlp-stores {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  gap: 12px;
+}
+
+.mlp-store-link {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.mlp-store-img {
+  height: 46px;
+  width: auto;
+  border-radius: 8px;
+  max-width: 100%;
+}
+
+/* ── Shared section chrome ──────────────── */
+.mlp-featured,
+.mlp-discover {
+  padding: 1.75rem 1.5rem;
+}
+
+.mlp-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.1rem;
+}
+
+.mlp-section-title {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 1.45rem;
+  font-weight: 400;
+  color: #ffffff;
+  margin: 0;
+}
+
+.mlp-see-all {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #47EFAC;
+  text-decoration: none;
+  opacity: 0.8;
+  transition: opacity 0.15s;
+}
+
+.mlp-see-all:active {
+  opacity: 1;
+}
+
+/* ── Featured card ──────────────────────── */
+.mlp-feat-card {
+  display: block;
+  text-decoration: none;
+  overflow: hidden;
+  transition: transform 0.22s ease;
+}
+
+.mlp-feat-card:active {
+  transform: scale(0.985);
+}
+
+.mlp-feat-img-wrap {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 3 / 2;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.mlp-feat-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.35s ease;
+}
+
+.mlp-feat-card:active .mlp-feat-img {
+  transform: scale(1.03);
+}
+
+/* Gradient overlay — text lives here */
+.mlp-feat-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 2.5rem 1.1rem 1.1rem;
+  background: linear-gradient(to top, rgba(4,14,46,0.95) 0%, rgba(4,14,46,0.6) 55%, transparent 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.22rem;
+}
+
+.mlp-feat-badge {
+  align-self: flex-start;
+  background: rgba(71, 239, 172, 0.15);
+  backdrop-filter: blur(8px);
+  color: #47EFAC;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  padding: 0.22rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(71, 239, 172, 0.3);
+  margin-bottom: 0.35rem;
+}
+
+.mlp-feat-title {
+  font-family: 'Inter', sans-serif;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #ffffff;
+  margin: 0;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.mlp-feat-artist {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.5);
+  margin: 0;
+}
+
+.mlp-feat-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 0.3rem;
+}
+
+.mlp-feat-price {
+  font-family: 'Inter', sans-serif;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #47EFAC;
+}
+
+.mlp-feat-cta {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.45);
+  letter-spacing: 0.2px;
+}
+
+/* ── Discover masonry grid ──────────────── */
+.mlp-grid {
+  columns: 2;
+  column-gap: 8px;
+}
+
+.mlp-grid-card {
+  display: inline-block;
+  width: 100%;
+  break-inside: avoid;
+  margin-bottom: 8px;
+  text-decoration: none;
+  overflow: hidden;
+  transition: transform 0.2s ease;
+}
+
+.mlp-grid-card:active {
+  transform: scale(0.97);
+}
+
+.mlp-grid-img-wrap {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.mlp-grid-img {
+  width: 100%;
+  height: auto;
+  display: block;
+  object-fit: cover;
+}
+
+/* Gradient overlay — fades in on the bottom portion */
+.mlp-grid-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 1.8rem 0.6rem 0.55rem;
+  background: linear-gradient(to top, rgba(4,14,46,0.9) 0%, transparent 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.mlp-grid-title {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: #ffffff;
+  margin: 0;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.mlp-grid-artist {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.65rem;
+  color: rgba(255, 255, 255, 0.48);
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mlp-grid-price {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #47EFAC;
+  margin: 0;
+}
+
+/* ── Explore CTA ────────────────────────── */
+.mlp-cta-row {
+  margin-top: 1.5rem;
+  display: flex;
+  justify-content: center;
+}
+
+.mlp-cta-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #072973;
+  border: 1.5px solid #47EFAC;
+  color: #47EFAC;
+  font-family: 'Josefin Sans', sans-serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  padding: 0.85rem 1.75rem;
+  border-radius: 0;
+  text-decoration: none;
+  transition: background 0.18s, color 0.18s;
+}
+
+.mlp-cta-btn:active {
+  background: #47EFAC;
+  color: #040e2e;
+}
+
+/* ── Loading state ──────────────────────── */
+.mlp-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 3rem 1.5rem;
+  gap: 1rem;
+}
+
+.mlp-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid rgba(71, 239, 172, 0.18);
+  border-top-color: #47EFAC;
+  border-radius: 50%;
+  animation: mlpSpin 0.8s linear infinite;
+}
+
+.mlp-loading-text {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.38);
+  margin: 0;
+}
+
+@keyframes mlpSpin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── Small phones ───────────────────────── */
+@media (max-width: 390px) {
+  .mlp-hero { padding: 5rem 1.25rem 2rem; }
+  .mlp-title { font-size: 2.75rem; }
+  .mlp-featured, .mlp-discover { padding: 1.5rem 1.25rem; }
+  .mlp-search-btn { padding: 1rem 1rem; font-size: 0.82rem; }
+}

--- a/src/components/LandingPage/MobileLanding.jsx
+++ b/src/components/LandingPage/MobileLanding.jsx
@@ -1,0 +1,260 @@
+import { useState, useEffect } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { API_URL } from "../../API_URL";
+import GooglePlay from '../../assets/headers/GooglePlay.png';
+import Apple from '../../assets/headers/Apple.png';
+import "./MobileLanding.css";
+
+function slugify(str) {
+  return str.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+function parseArtworkId(rawId) {
+  const str = String(rawId);
+  return str.includes(":") ? str.split(":")[1] : str;
+}
+
+const TRENDING = ["Abstract", "Portrait", "Van Gogh", "Photography", "Sculpture", "NYC Art"];
+
+export default function MobileLanding({ searchQuery, setSearchQuery, onSearch }) {
+  const navigate = useNavigate();
+  const [artworks, setArtworks] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      const [mktRes, pdRes] = await Promise.allSettled([
+        fetch(`${API_URL}/marketplace?limit=12&sort=newest`).then(r => r.json()),
+        fetch(`${API_URL}/public-art/featured`).then(r => r.json()),
+      ]);
+
+      const mkt = (mktRes.status === "fulfilled" && mktRes.value.success)
+        ? mktRes.value.images
+            .filter(img => img.imageLink)
+            .slice(0, 8)
+            .map(img => ({
+              id: img._id,
+              type: "marketplace",
+              src: img.imageLink,
+              title: img.name || "Untitled",
+              artist: img.artistName || "Unknown Artist",
+              price: img.price ? `$${Number(img.price).toLocaleString()}` : null,
+              medium: img.category || null,
+              href: `/marketplace/${slugify(img.artistName || "artist")}/${slugify(img.name || "artwork")}-${img._id}`,
+            }))
+        : [];
+
+      const pd = (pdRes.status === "fulfilled" && pdRes.value.success)
+        ? pdRes.value.data
+            .filter(a => a.thumbnailUrl || a.imageUrl)
+            .slice(0, 10)
+            .map(a => ({
+              id: String(a.id),
+              type: "public",
+              src: a.thumbnailUrl || a.imageUrl,
+              title: a.title || "Untitled",
+              artist: a.artistDisplayName || a.artistName || "Unknown Artist",
+              medium: a.medium || null,
+              dimensions: a.dimensions || null,
+              href: `/art/${a.source || "met"}/${parseArtworkId(a.id)}`,
+            }))
+        : [];
+
+      // Interleave marketplace first, public domain second
+      const merged = [];
+      const max = Math.max(mkt.length, pd.length);
+      for (let i = 0; i < max; i++) {
+        if (mkt[i]) merged.push(mkt[i]);
+        if (pd[i]) merged.push(pd[i]);
+      }
+
+      setArtworks(merged.slice(0, 13));
+      setLoading(false);
+    }
+    load();
+  }, []);
+
+  const featured = artworks[0] ?? null;
+  const grid = artworks.slice(1, 11);
+
+  return (
+    <div className="mlp">
+
+      {/* ── Hero ── */}
+      <section className="mlp-hero">
+
+        {/* Paint splashes — top-left teal */}
+        <svg className="mlp-splash mlp-splash-tl" viewBox="0 0 240 260" fill="none" aria-hidden="true">
+          <path d="M-10,50 C10,5 55,-5 95,18 C135,41 148,82 168,98 C188,114 218,102 228,122 C238,142 220,174 198,180 C176,186 150,162 128,168 C106,174 94,202 70,196 C46,190 18,168 8,140 C-2,112 -30,95 -10,50Z" fill="rgba(71,239,172,0.045)" />
+          <path d="M58,168 C60,188 57,208 61,220 C62,225 59,222 58,213 C56,198 59,180 58,168Z" fill="rgba(71,239,172,0.038)" />
+          <path d="M96,175 C98,191 97,205 100,213 C101,217 99,213 98,205 C96,194 97,186 96,175Z" fill="rgba(71,239,172,0.03)" />
+          <circle cx="12" cy="12" r="3.5" fill="rgba(71,239,172,0.07)" />
+          <circle cx="32" cy="4" r="2" fill="rgba(71,239,172,0.05)" />
+          <circle cx="4" cy="38" r="2.5" fill="rgba(71,239,172,0.04)" />
+          <circle cx="178" cy="28" r="1.5" fill="rgba(71,239,172,0.05)" />
+          <circle cx="148" cy="8" r="1" fill="rgba(71,239,172,0.04)" />
+          <circle cx="68" cy="5" r="1.5" fill="rgba(71,239,172,0.03)" />
+        </svg>
+
+        {/* Paint splash — top-right blue */}
+        <svg className="mlp-splash mlp-splash-tr" viewBox="0 0 200 200" fill="none" aria-hidden="true">
+          <path d="M200,0 C178,28 155,12 128,34 C101,56 112,90 90,102 C68,114 40,98 24,115 C8,132 20,165 42,170 C64,175 92,152 114,147 C136,142 162,158 184,146 C206,134 214,102 204,75 C194,48 222,-28 200,0Z" fill="rgba(126,184,255,0.032)" />
+          <circle cx="188" cy="8" r="2.5" fill="rgba(126,184,255,0.055)" />
+          <circle cx="165" cy="2" r="1.5" fill="rgba(126,184,255,0.04)" />
+          <circle cx="196" cy="28" r="2" fill="rgba(126,184,255,0.04)" />
+          <circle cx="145" cy="15" r="1" fill="rgba(126,184,255,0.03)" />
+        </svg>
+
+        <p className="mlp-eyebrow">✦ ART SEARCH ENGINE &amp; MARKETPLACE</p>
+
+        <h1 className="mlp-title">
+          Find Art.<br />
+          <span className="mlp-accent">Own It.</span>
+        </h1>
+
+        <p className="mlp-subtitle">
+          Search thousands of artworks, discover emerging artists, and buy originals directly from creators.
+        </p>
+
+        {/* Search bar */}
+        <form className="mlp-search" onSubmit={onSearch}>
+          <svg className="mlp-search-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" />
+          </svg>
+          <input
+            type="text"
+            className="mlp-search-input"
+            placeholder="Search art, artist, style..."
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+          />
+          <button type="submit" className="mlp-search-btn">Search</button>
+        </form>
+
+        {/* Trending chips */}
+        <div className="mlp-trending">
+          <span className="mlp-trending-label">Trending</span>
+          <div className="mlp-chip-row">
+            {TRENDING.map(term => (
+              <button
+                key={term}
+                className="mlp-chip"
+                onClick={() => navigate(`/search?q=${encodeURIComponent(term)}`)}
+              >
+                {term}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* App store buttons */}
+        <div className="mlp-stores">
+          <a
+            href="https://play.google.com/store/apps/details?id=com.immpression.artapp"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mlp-store-link"
+          >
+            <img src={GooglePlay} alt="Get it on Google Play" className="mlp-store-img" />
+          </a>
+          <a
+            href="https://apps.apple.com/app/id6756974604"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mlp-store-link"
+          >
+            <img src={Apple} alt="Download on the App Store" className="mlp-store-img" />
+          </a>
+        </div>
+
+      </section>
+
+      {/* ── Featured Artwork ── */}
+      {!loading && featured && (
+        <section className="mlp-featured">
+          <div className="mlp-section-head">
+            <h2 className="mlp-section-title">Featured Artwork</h2>
+            <Link
+              to={featured.type === "marketplace" ? "/marketplace" : "/explore"}
+              className="mlp-see-all"
+            >
+              See all →
+            </Link>
+          </div>
+
+          <Link to={featured.href} className="mlp-feat-card">
+            <div className="mlp-feat-img-wrap">
+              <img
+                src={featured.src}
+                alt={featured.title}
+                className="mlp-feat-img"
+                loading="lazy"
+              />
+              <div className="mlp-feat-overlay">
+                <span className="mlp-feat-badge">
+                  {featured.type === "marketplace" ? "Original" : "Public Domain"}
+                </span>
+                <h3 className="mlp-feat-title">{featured.title}</h3>
+                <p className="mlp-feat-artist">by {featured.artist}</p>
+                <div className="mlp-feat-footer">
+                  {featured.price && <span className="mlp-feat-price">{featured.price}</span>}
+                  <span className="mlp-feat-cta">View →</span>
+                </div>
+              </div>
+            </div>
+          </Link>
+        </section>
+      )}
+
+      {/* ── Discover Grid ── */}
+      {!loading && grid.length > 0 && (
+        <section className="mlp-discover">
+          <div className="mlp-section-head">
+            <h2 className="mlp-section-title">Discover</h2>
+            <Link to="/explore" className="mlp-see-all">Explore all →</Link>
+          </div>
+
+          <div className="mlp-grid">
+            {grid.map(art => (
+              <Link key={art.id} to={art.href} className="mlp-grid-card">
+                <div className="mlp-grid-img-wrap">
+                  <img
+                    src={art.src}
+                    alt={art.title}
+                    className="mlp-grid-img"
+                    loading="lazy"
+                  />
+                  <div className="mlp-grid-overlay">
+                    <p className="mlp-grid-title">{art.title}</p>
+                    {art.price
+                      ? <span className="mlp-grid-price">{art.price}</span>
+                      : <span className="mlp-grid-artist">{art.artist}</span>
+                    }
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+
+          <div className="mlp-cta-row">
+            <Link to="/explore" className="mlp-cta-btn">
+              Explore More Art
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M5 12h14M13 6l6 6-6 6"/>
+              </svg>
+            </Link>
+          </div>
+        </section>
+      )}
+
+      {/* Loading skeleton */}
+      {loading && (
+        <div className="mlp-loading">
+          <div className="mlp-spinner" />
+          <p className="mlp-loading-text">Loading artworks…</p>
+        </div>
+      )}
+
+    </div>
+  );
+}


### PR DESCRIPTION
- Add MobileLanding component: search-first hero, trending chips, app store buttons, featured artwork card with gradient overlay, 2-col masonry discover grid
- Hide desktop hero-section on mobile (≤768px); MobileLanding replaces it
- HowItWorks mobile: reset explicit grid-column placements so items stack, remove margin-left:auto on text col, reduce label gap from 6rem to 1.75rem, tighten section padding
- HowItWorks mobile: add CSS phone mockup (ImmpressionHome.png) with Dynamic Island, side buttons, home indicator — shown at ≤960px instead of 3D model
- Art cards: gradient overlay text (title, artist, price) directly on image, no separate body block, no rounded corners
- Explore CTA button: sharp corners, navy fill, Josefin Sans uppercase, teal border with arrow


Claude-Session: https://claude.ai/code/session_01QK3pHMoW7QKDnr4DGNXcDe