### PR TITLE
Polish artwork detail page and center landing page hero text

### DIFF
--- a/src/components/LandingPage/LandingPage.css
+++ b/src/components/LandingPage/LandingPage.css
@@ -57,6 +57,7 @@
 
 .hero-left {
   max-width: 600px;
+  margin: 0 auto;
 }
 
 /* Eyebrow text (replaces badge bubble) */

--- a/src/components/Marketplace/ArtworkDetail.css
+++ b/src/components/Marketplace/ArtworkDetail.css
@@ -11,11 +11,19 @@
 
 /* ─── Breadcrumb ──────────────────────────────── */
 .artwork-detail-breadcrumb {
-  max-width: 1180px;
+  max-width: 1280px;
   margin: 0 auto 2rem;
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.artwork-detail-breadcrumb-left {
+  display: flex;
+  align-items: center;
   gap: 0.5rem;
+  flex-shrink: 0;
   flex-wrap: wrap;
 }
 
@@ -71,6 +79,67 @@
   align-items: start;
 }
 
+
+.artwork-detail-search-form {
+  display: flex;
+  align-items: center;
+  background: #fff;
+  border: 1px solid rgba(0,0,0,0.10);
+  border-radius: 9999px;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.22), 0 1px 3px rgba(0,0,0,0.14);
+  transition: border-color 0.25s, box-shadow 0.25s;
+  flex: 1;
+}
+
+.artwork-detail-search-form:focus-within {
+  border-color: rgba(0,0,0,0.18);
+  box-shadow: 0 3px 10px rgba(0,0,0,0.28), 0 1px 4px rgba(0,0,0,0.16);
+}
+
+.artwork-detail-search-icon {
+  flex-shrink: 0;
+  width: 17px;
+  height: 17px;
+  color: #aaa;
+  margin-left: 1rem;
+}
+
+.artwork-detail-search-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  padding: 1rem 0.75rem;
+  font-size: 1rem;
+  font-family: 'Inter', sans-serif;
+  color: #111;
+}
+
+.artwork-detail-search-input::placeholder {
+  color: rgba(0,0,0,0.35);
+}
+
+.artwork-detail-search-btn {
+  flex-shrink: 0;
+  background: #111;
+  color: #fff;
+  border: none;
+  padding: 0.7rem 1.4rem;
+  margin: 4px;
+  border-radius: 9999px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  font-family: 'Inter', sans-serif;
+  letter-spacing: 0.3px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.artwork-detail-search-btn:hover {
+  background: #333;
+}
+
 /* ─── Image column ────────────────────────────── */
 .artwork-detail-image-col {
   position: sticky;
@@ -79,7 +148,7 @@
 
 .artwork-detail-image-wrap {
   width: 100%;
-  border-radius: 10px;
+  border-radius: 0;
   overflow: hidden;
   background: #f5f5f5;
   border: 1px solid #ebebeb;
@@ -112,7 +181,7 @@
   background: rgba(255, 255, 255, 0.9);
   border: 1px solid #ddd;
   padding: 0.25rem 0.65rem;
-  border-radius: 3px;
+  border-radius: 4px;
 }
 
 .artwork-detail-views {
@@ -184,7 +253,7 @@
   color: #aaa;
   border: 1px solid #ddd;
   padding: 0.25rem 0.65rem;
-  border-radius: 3px;
+  border-radius: 4px;
 }
 
 /* ─── Sections ────────────────────────────────── */
@@ -259,60 +328,25 @@
 
 .artwork-detail-app-links {
   display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
+  flex-direction: row;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
-.artwork-detail-app-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.6rem;
-  font-family: 'Josefin Sans', sans-serif;
-  font-size: 0.68rem;
-  font-weight: 600;
-  letter-spacing: 2.5px;
-  text-transform: uppercase;
-  text-decoration: none;
-  padding: 0.85rem 2rem;
+.artwork-detail-store-btn {
+  display: inline-block;
+  transition: transform 0.2s ease;
+}
+
+.artwork-detail-store-btn:hover {
+  transform: translateY(-3px);
+}
+
+.artwork-detail-store-img {
+  height: 52px;
+  width: auto;
   border-radius: 6px;
-  transition: all 0.2s ease;
-  background: #111;
-  color: #fff;
-  border: 1px solid #111;
-}
-
-.artwork-detail-app-icon {
-  width: 18px;
-  height: 18px;
-  object-fit: contain;
-  flex-shrink: 0;
-  filter: brightness(0) invert(1);
-}
-
-.artwork-detail-app-btn:hover {
-  background: #333;
-  border-color: #333;
-}
-
-.artwork-detail-app-btn.secondary {
-  background: transparent;
-  color: #888;
-  border: 1px solid #ddd;
-}
-
-.artwork-detail-app-btn.secondary .artwork-detail-app-icon {
-  filter: brightness(0) opacity(0.5);
-}
-
-.artwork-detail-app-btn.secondary:hover {
-  color: #111;
-  border-color: #999;
-  background: transparent;
-}
-
-.artwork-detail-app-btn.secondary:hover .artwork-detail-app-icon {
-  filter: brightness(0) opacity(0.85);
+  display: block;
 }
 
 /* ─── States ──────────────────────────────────── */
@@ -378,41 +412,50 @@
 .artwork-detail-more-label {
   display: block;
   font-family: 'Josefin Sans', sans-serif;
-  font-size: 0.6rem;
-  font-weight: 600;
-  letter-spacing: 3px;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 2.5px;
   text-transform: uppercase;
-  color: #bbb;
-  margin-bottom: 1.25rem;
+  color: #999;
+  margin-bottom: 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid #ebebeb;
 }
 
 .artwork-detail-more-list {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0;
 }
 
 .artwork-detail-more-card {
   display: flex;
-  gap: 0.85rem;
+  gap: 1rem;
   text-decoration: none;
-  align-items: flex-start;
-  padding: 0.6rem;
-  border-radius: 8px;
-  border: 1px solid transparent;
-  transition: border-color 0.2s ease, background 0.2s ease;
+  align-items: center;
+  padding: 0.75rem 0;
+  border-radius: 0;
+  border-bottom: 1px solid #f0f0f0;
+  transition: background 0.15s ease;
+}
+
+.artwork-detail-more-card:last-child {
+  border-bottom: none;
 }
 
 .artwork-detail-more-card:hover {
-  border-color: #ebebeb;
   background: #fafafa;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
 }
 
 .artwork-detail-more-img-wrap {
-  width: 72px;
-  height: 72px;
+  width: 80px;
+  height: 80px;
   flex-shrink: 0;
-  border-radius: 6px;
+  border-radius: 0;
   overflow: hidden;
   background: #f5f5f5;
 }
@@ -422,11 +465,11 @@
   height: 100%;
   object-fit: cover;
   display: block;
-  transition: transform 0.35s ease;
+  transition: transform 0.3s ease;
 }
 
 .artwork-detail-more-card:hover .artwork-detail-more-img-wrap img {
-  transform: scale(1.06);
+  transform: scale(1.07);
 }
 
 .artwork-detail-more-info {
@@ -434,16 +477,16 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.15rem;
+  gap: 0.2rem;
 }
 
 .artwork-detail-more-artist {
   font-family: 'Josefin Sans', sans-serif;
-  font-size: 0.58rem;
+  font-size: 0.6rem;
   font-weight: 600;
   letter-spacing: 1.5px;
   text-transform: uppercase;
-  color: #bbb;
+  color: #aaa;
   margin: 0;
   white-space: nowrap;
   overflow: hidden;
@@ -452,7 +495,7 @@
 
 .artwork-detail-more-name {
   font-family: 'Inter', sans-serif;
-  font-size: 0.8rem;
+  font-size: 0.82rem;
   font-weight: 500;
   color: #1a1a1a;
   margin: 0;
@@ -464,11 +507,12 @@
 }
 
 .artwork-detail-more-price {
-  font-family: 'Josefin Sans', sans-serif;
-  font-size: 0.78rem;
-  font-weight: 600;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.8rem;
+  font-weight: 700;
   color: #111;
-  margin: 0.2rem 0 0;
+  margin: 0;
+  letter-spacing: -0.2px;
 }
 
 /* ─── Responsive ──────────────────────────────── */

--- a/src/components/Marketplace/ArtworkDetail.jsx
+++ b/src/components/Marketplace/ArtworkDetail.jsx
@@ -21,6 +21,7 @@ const ArtworkDetail = () => {
 
   const id = extractId(artworkSlug);
   const [moreArtworks, setMoreArtworks] = useState([]);
+  const [searchQuery, setSearchQuery] = useState("");
 
   useEffect(() => {
     if (!id) {
@@ -152,15 +153,33 @@ const ArtworkDetail = () => {
         })}</script>
       </Helmet>
 
-      {/* Breadcrumb */}
+      {/* Breadcrumb + search on same row */}
       <div className="artwork-detail-breadcrumb">
-        <Link to="/marketplace" className="artwork-detail-back-link">
-          ← Marketplace
-        </Link>
-        <span className="artwork-detail-breadcrumb-sep">/</span>
-        <span className="artwork-detail-breadcrumb-artist">{artistName}</span>
-        <span className="artwork-detail-breadcrumb-sep">/</span>
-        <span className="artwork-detail-breadcrumb-name">{name}</span>
+        <div className="artwork-detail-breadcrumb-left">
+          <Link to="/marketplace" className="artwork-detail-back-link">
+            ← Marketplace
+          </Link>
+          <span className="artwork-detail-breadcrumb-sep">/</span>
+          <span className="artwork-detail-breadcrumb-artist">{artistName}</span>
+          <span className="artwork-detail-breadcrumb-sep">/</span>
+          <span className="artwork-detail-breadcrumb-name">{name}</span>
+        </div>
+        <form
+          className="artwork-detail-search-form"
+          onSubmit={e => { e.preventDefault(); if (searchQuery.trim()) navigate(`/search?q=${encodeURIComponent(searchQuery.trim())}`); }}
+        >
+          <svg className="artwork-detail-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+          </svg>
+          <input
+            className="artwork-detail-search-input"
+            type="text"
+            placeholder="Search artworks, artists…"
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+          />
+          <button type="submit" className="artwork-detail-search-btn">Search</button>
+        </form>
       </div>
 
       <div className="artwork-detail-inner">
@@ -259,19 +278,17 @@ const ArtworkDetail = () => {
                   href="https://apps.apple.com/app/immpression/id6739459806"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="artwork-detail-app-btn"
+                  className="artwork-detail-store-btn"
                 >
-                  <img src={appleIcon} alt="Apple App Store" className="artwork-detail-app-icon" />
-                  Download on App Store
+                  <img src={appleIcon} alt="Download on the App Store" className="artwork-detail-store-img" />
                 </a>
                 <a
                   href="https://play.google.com/store/apps/details?id=com.immpression.app"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="artwork-detail-app-btn secondary"
+                  className="artwork-detail-store-btn"
                 >
-                  <img src={googlePlayIcon} alt="Google Play Store" className="artwork-detail-app-icon" />
-                  Get on Google Play
+                  <img src={googlePlayIcon} alt="Get it on Google Play" className="artwork-detail-store-img" />
                 </a>
               </div>
             </div>
@@ -287,7 +304,7 @@ const ArtworkDetail = () => {
             transition={{ duration: 0.55, delay: 0.2 }}
           >
             <span className="artwork-detail-more-label">
-              More {category ? category : "artwork"}
+              More Artworks
             </span>
             <div className="artwork-detail-more-list">
               {moreArtworks.map((art) => {


### PR DESCRIPTION
- Hero left column centered within its grid half (margin: 0 auto)
- Artwork detail: replace store buttons with image badges matching landing page
- Add inline search bar next to breadcrumb (pill shape, drop shadow)
- 'More Artworks' section: polished cards, dividers, bigger thumbnails
- Remove rounded corners from artwork/tags, slight radius on buttons


Claude-Session: https://claude.ai/code/session_01QK3pHMoW7QKDnr4DGNXcDe